### PR TITLE
Improve build caching behavior

### DIFF
--- a/nala/Dockerfile
+++ b/nala/Dockerfile
@@ -17,17 +17,18 @@ RUN . anomaly_detection/venv/bin/activate
 ENV PATH="/app/nala/anomaly_detection/venv/bin:$PATH"
 RUN python3.11 -m pip install -r anomaly_detection/requirements.txt
 
-# Copy nala source code
+# Copy dependencies
 WORKDIR /app
 COPY nala/go.mod nala/go.sum ./nala/
 COPY internal/ ./internal/
-COPY nala/*.go ./nala/
-COPY nala/testpy.py ./nala/
-
 
 # Get Go dependencies
 WORKDIR /app/nala
 RUN go mod download
+
+# Copy source code
+COPY nala/*.go ./
+COPY nala/testpy.py ./
 
 # Build nala binary
 RUN go build -o /nala


### PR DESCRIPTION
By moving the installation of dependencies higher up in the dockerfile it will be cached even if the nala source code changes. This will drastically improve build times. See https://docs.docker.com/build/cache/#how-can-i-use-the-cache-efficiently for more information